### PR TITLE
Fix ArrayIndexOutOfBoundsException if you select a dog that is about to run

### DIFF
--- a/core/src/com/mygdx/game/GameRenderer.java
+++ b/core/src/com/mygdx/game/GameRenderer.java
@@ -201,7 +201,7 @@ public class GameRenderer implements Disposable, Observer {
 	}
 
 	private void drawPath() {
-		if (selectedCharacter != null && selectedCharacter.pathToRender.size > 0) {
+		if (selectedCharacter != null && selectedCharacter.pathToRender.size > 0 && selectedCharacter.getCurrentSegmentIndex() >= 0) {
 			shapeRenderer.setProjectionMatrix(viewport.getCamera().combined);
 			shapeRenderer.begin(MyShapeRenderer.ShapeType.Line);
 			shapeRenderer.setColor(Color.CORAL);


### PR DESCRIPTION
This fixes the exception occurring when `drawPath` is checked and you whistle and rapidly select the dog before he starts to run.