### PR TITLE
Avoid NaN due to the indeterminate form 0/0

### DIFF
--- a/core/src/com/mygdx/game/utilities/GeometryUtils.java
+++ b/core/src/com/mygdx/game/utilities/GeometryUtils.java
@@ -23,12 +23,14 @@ public class GeometryUtils {
 		float abX = end.x - start.x;
 		float abY = end.y - start.y;
 		float abZ = end.z - start.z;
-		float t = ((point.x - start.x) * abX + (point.y - start.y) * abY + (point.z - start.z) * abZ) /
-				(abX * abX + abY * abY + abZ * abZ);
-		float s = MathUtils.clamp(t, 0, 1);
-		nearest.x += abX * s;
-		nearest.y += abY * s;
-		nearest.z += abZ * s;
+		float abLen2 = abX * abX + abY * abY + abZ * abZ;
+		if (abLen2 > 0) { // Avoid NaN due to the indeterminate form 0/0
+			float t = ((point.x - start.x) * abX + (point.y - start.y) * abY + (point.z - start.z) * abZ) / abLen2;
+			float s = MathUtils.clamp(t, 0, 1);
+			nearest.x += abX * s;
+			nearest.y += abY * s;
+			nearest.z += abZ * s;
+		}
 		return nearest.dst2(point);
 	}
 


### PR DESCRIPTION
This fix correctly treats the segment as a point when `start.equals(end)`