### PR TITLE
Fix path following ending on stairs

### DIFF
--- a/core/src/com/mygdx/game/GameEngine.java
+++ b/core/src/com/mygdx/game/GameEngine.java
@@ -94,7 +94,7 @@ public class GameEngine extends PooledEngine implements Disposable, Observer {
 
 			if (entity instanceof GameModel) {
 				GameModel model = (GameModel) entity;
-				if (hitFraction < this.hitFraction && model.visibleOnLayers.intersects(layers)) {
+				if (hitFraction < this.hitFraction && (layers == null || model.visibleOnLayers.intersects(layers))) {
 					this.hitFraction = hitFraction;
 					super.addSingleResult(rayResult, normalInWorldSpace);
 					return hitFraction;
@@ -182,7 +182,9 @@ public class GameEngine extends PooledEngine implements Disposable, Observer {
 		dynamicsWorld.rayTest(rayFrom, rayTo, callback);
 
 		if (callback.hasHit()) {
-			callback.getHitPointWorld(hitPointWorld);
+			if (hitPointWorld != null) {
+				callback.getHitPointWorld(hitPointWorld);
+			}
 			long entityId = callback.getCollisionObject().getUserPointer();
 			return getEntity(entityId);
 		}

--- a/core/src/com/mygdx/game/objects/SteerableBody.java
+++ b/core/src/com/mygdx/game/objects/SteerableBody.java
@@ -168,7 +168,7 @@ public class SteerableBody extends GameModelBody implements Steerable<Vector3> {
 			// Apply steering acceleration since this character is steering
 			applySteering(steeringOutput, deltaTime);
 			
-		} else if (wasSteering) {
+		} else { //if (wasSteering) {
 			// Stop steering since this character is not steering now but was steering before
 			stopSteering(true);
 		}
@@ -181,7 +181,6 @@ public class SteerableBody extends GameModelBody implements Steerable<Vector3> {
 	protected void startSteering() {
 		wasSteering = true;
 		body.setFriction(0);
-		body.setGravity(Vector3.Zero);
 		modelTransform.getRotation(currentOrientation, true);
 		if (steerer != null) {
 			steerer.startSteering();
@@ -206,8 +205,6 @@ public class SteerableBody extends GameModelBody implements Steerable<Vector3> {
 				currentOrientation.getPitch(),
 				currentOrientation.getRoll()).setTranslation(position);
 		body.setWorldTransform(modelTransform);
-
-		body.setGravity(GameEngine.engine.dynamicsWorld.getGravity());
 
 		if (steerer != null) {
 			clearLinearVelocity = steerer.stopSteering();


### PR DESCRIPTION
- Don't disable gravity while steering.
- Increase acceleration when the entity detects a small obstacle at his
feet like the step of the stairs.
- Now `rayTest` supports `null` layers which stands for all layers.

You should see two rays when this trick occurs. This is especially noticeable when crunching, since the speed is low.